### PR TITLE
fix error thrown on failed connection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,5 @@ gem 'mechanize', '~> 2.7', '>= 2.7.3'
 gem 'logger', '~> 1.2', '>= 1.2.8'
 # JSON parser for ruby
 gem 'json', '~> 1.8', '>= 1.8.3'
+# rspec for BDD testing
+gem 'rspec', '~> 3.4' 

--- a/helpers/connection.rb
+++ b/helpers/connection.rb
@@ -2,7 +2,7 @@
 # surpasses any error raised in the process and returns false
 def accessable?(url)
   open(url)
-rescue OpenURI::HTTPError
+rescue StandardError
   false
 end
 

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+require 'open-uri'
+
+describe "#can_be_reached?" do  
+    it "should not throw an error when connection fails" do
+      expect { can_be_reached? 1, 'http://invalidUrl123.com', 1 }.to_not raise_error
+    end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,1 @@
+require_relative '../helpers/connection.rb'


### PR DESCRIPTION
I've done a bit of testing and discovered that OpenURI::HTTPError does not rescue from exceptions like Errno::EHOSTUNREACH which arises when a host is not reachable (e.g: upassbc.translink.ca is down). In order to recover from all connection exceptions, we should rescue from StandardError. I have provided a test to verify this.